### PR TITLE
Restructure homepage UI elements and map

### DIFF
--- a/frontend/src/css/home.css
+++ b/frontend/src/css/home.css
@@ -39,8 +39,8 @@
 
 /* Centered Map Container */
 .map-container {
-  height: 500px;
-  width: 60%;
+  height: 650px;
+  width: 100%;
   margin: 0 auto;
   border-radius: 12px;
   overflow: hidden;

--- a/frontend/src/pages/HomePage.js
+++ b/frontend/src/pages/HomePage.js
@@ -126,6 +126,7 @@ const HomePage = () => {
   const totalProjects = projects.length;
 
   return (
+    <>
     <div className="home-page">
       <div className="ghana-header">
         <h1 className="page-title">Ghana Project Tracker</h1>
@@ -137,16 +138,22 @@ const HomePage = () => {
         )}
       </div>
 
-      <div className="hero-section">
-        <div className="stats-banner">
-          <div className="stat-item">
-            <div className="stat-value">{totalProjects}</div>
-            <div className="stat-label">Total Projects</div>
-          </div>    
-        </div>
+      <div className="stats-banner">
+        <div className="stat-item">
+          <div className="stat-value">{totalProjects}</div>
+          <div className="stat-label">Total Projects</div>
+        </div>    
+      </div>
 
+      <div className="hero-section">
         <div className="map-container">
-          <MapContainer center={[7.9465, -1.0232]} zoom={5} style={{ height: '100%', width: '100%' }}>
+          <MapContainer 
+            center={[7.9465, -1.0232]} 
+            zoom={6} 
+            maxBounds={[[4.5, -3.2], [11.2, 1.3]]}
+            maxBoundsViscosity={0.9}
+            style={{ height: '100%', width: '100%' }}
+          >
             <TileLayer
               url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
               attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
@@ -271,8 +278,9 @@ const HomePage = () => {
         />
       )}
       
-      <Footer/>
     </div>
+    <Footer/>
+    </>
   );
 };
 


### PR DESCRIPTION
Restructure homepage layout to improve visual hierarchy, map focus, and footer width.

The changes address user requests to elevate the 'Total Projects' banner, make the map larger and constrained to Ghana's regions, and ensure the footer spans the full page width.

---
<a href="https://cursor.com/background-agent?bcId=bc-45a3baa5-16ae-450f-94bc-724ddbbfc9e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-45a3baa5-16ae-450f-94bc-724ddbbfc9e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

